### PR TITLE
Allow creating rows for tables where primary column name isn't "id"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.sw*
+.idea
 
 # Logs
 logs

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1040,7 +1040,7 @@ module.exports = (function () {
                                 return cb(handleQueryError(err, 'create'));
                             }
                             
-                            var selectQuery = 'select * from "'+table+'" order by "id" desc';
+                            var selectQuery = 'select * from "'+table+'" order by "' + _getPK(connectionName, table) +'" desc';
                             connection.execute(selectQuery, [],  {maxRows:1, outFormat: oracledb.OBJECT}, function __CREATE_SELECT__(err, result){
                                 
                                 if (err){


### PR DESCRIPTION
This also will solve an issue [#4](https://github.com/baitic/sails-oradb/issues/4)
